### PR TITLE
Fixed a bug that prevents the rest method restriction. Methods Property ...

### DIFF
--- a/collectionapi.js
+++ b/collectionapi.js
@@ -69,7 +69,7 @@ CollectionAPI.prototype.start = function() {
 
 CollectionAPI.prototype._collectionOptions = function(requestPath) {
   var self = this;
-  return self._collections[requestPath.collectionName] ? self._collections[requestPath.collectionName].options : undefined;
+  return self._collections[requestPath.collectionPath] ? self._collections[requestPath.collectionPath].options : undefined;
 };
 
 CollectionAPI._requestListener = function (server, request, response) {


### PR DESCRIPTION
...in collectionAPI.addCollection didn't work.

Found that restricting collections to only a subset of methods (like only GET) didn't work. So that should fix it.

Greetings,
Andreas
