### PR TITLE
Allow HTTP form POST in addition to HTTP json POST

### DIFF
--- a/collectionapi.js
+++ b/collectionapi.js
@@ -205,7 +205,11 @@ CollectionAPI._requestListener.prototype._putRequest = function() {
       try {
         self._requestCollection.update(self._requestPath.collectionId, JSON.parse(requestData));
       } catch (e) {
-        return self._internalServerErrorResponse(e);
+        try {
+          self._requestCollection.update(self._requestPath.collectionId, self._server._querystring.parse(requestData));
+        } catch (e) {
+          return self._internalServerErrorResponse(e);
+        }
       }
       return self._getRequest();
     }).run();
@@ -243,7 +247,11 @@ CollectionAPI._requestListener.prototype._postRequest = function() {
       try {
         self._requestPath.collectionId = self._requestCollection.insert(JSON.parse(requestData));
       } catch (e) {
-        return self._internalServerErrorResponse(e);
+        try {
+          self._requestPath.collectionId = self._requestCollection.insert(self._server._querystring.parse(requestData));
+        } catch (e) {
+          return self._internalServerErrorResponse(e);
+        }
       }
       return self._createdResponse(JSON.stringify({_id: self._requestPath.collectionId}));
     }).run();


### PR DESCRIPTION
Although the optimal and most common way is to send JSON data to a REST
API, there are cases when you need to use existing systems to POST and
PUT data. These can send a common HTTP form like 
"value1=data1&data2=value2"

Check if the submitted data is in JSON format. If it is not, try to use
querystring.parse(requestData) to convert the requestData to JSON
format. If this does not work either, send the error message to the
client.
