### PR TITLE
Fixed `ReferenceError: Fiber is not defined` for meteor 0.6.0 

### DIFF
--- a/collectionapi.js
+++ b/collectionapi.js
@@ -1,3 +1,5 @@
+Fiber = Npm.require('fibers');
+
 CollectionAPI = function(options) {
   var self = this;
 


### PR DESCRIPTION
I realized that #12 did not fix collectionapi for GET requests. Upon making a GET request I got the `ReferenceError: Fiber is not defined` error. I resolved this just by requiring `fibers`.
