### PR TITLE
Fix content length in response

### DIFF
--- a/collectionapi.js
+++ b/collectionapi.js
@@ -283,7 +283,7 @@ CollectionAPI._requestListener.prototype._internalServerErrorResponse = function
 CollectionAPI._requestListener.prototype._sendResponse = function(statusCode, body) {
   var self = this;
   self._response.statusCode = statusCode;
-  self._response.setHeader('Content-Length', body.length);
+  self._response.setHeader('Content-Length', Buffer.byteLength(body, 'utf8'));
   self._response.setHeader('Content-Type', 'application/json');
   self._response.write(body);
   self._response.end();


### PR DESCRIPTION
Fix content length for responses with body encoded in utf8

this might fix #6
